### PR TITLE
multiple: run ci on main && test updates

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/provenance_lib/tests/test_replay.py
+++ b/provenance_lib/tests/test_replay.py
@@ -255,11 +255,11 @@ class ReplayProvDAGDirectoryTests(unittest.TestCase):
 
         exp = (
             '(?s)from qiime2 import Artifact.*'
-            'emp_single_end_sequences_0 = Artifact.import_data.*'
-            'EMPSingleEndSequences.*'
-            '<your data here>.*'
             'multiplexed_single_end_barcode_in_sequence_0 = Artifact.import.*'
             'MultiplexedSingleEndBarcodeInSequence.*'
+            '<your data here>.*'
+            'emp_single_end_sequences_0 = Artifact.import_data.*'
+            'EMPSingleEndSequences.*'
             '<your data here>.*'
         )
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
I noticed the github actions workflow wasn't running on pushes to main so the first commit here updates that, and the second commit tweaks a test that is currently failing (probably bc ci didn't run on the related commits).